### PR TITLE
Fix send_test_email to allow no authentication 

### DIFF
--- a/src/Shell/Task/SendTestEmailTask.php
+++ b/src/Shell/Task/SendTestEmailTask.php
@@ -213,8 +213,8 @@ class SendTestEmailTask extends AppShell
     {
         $transportConfig = TransportFactory::getConfig('default');
         $usernameClear = $transportConfig['username'];
-        $usernameEncoded = base64_encode($transportConfig['username']);
-        $passwordClear = base64_encode($transportConfig['password']);
+        $usernameEncoded = base64_encode($transportConfig['username']??'');
+        $passwordClear = base64_encode($transportConfig['password']??'');
         $passwordEncoded = $transportConfig['password'];
         $replaced = str_replace(
             [$usernameClear, $usernameEncoded, $passwordClear, $passwordEncoded],
@@ -232,7 +232,7 @@ class SendTestEmailTask extends AppShell
      */
     protected function _getDefaultMessage()
     {
-        $message = "Congratulations!\n" .
+        $message = 'Congratulations!\n' .
         'If you receive this email, it means that your passbolt smtp configuration is working fine.';
 
         return $message;


### PR DESCRIPTION
This pull request is a (multiple allowed):

* [x] bug fix
* [x] change of existing behavior
* [ ] new feature

Checklist
* [x] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did
As in title this PR fix `send_test_email` to allow no authentication and prevent the following exception
```
Exception: base64_encode() expects parameter 1 to be string, null given in [/[...]/passbolt/src/Shell/Task/SendTestEmailTask.php, line 216]
```
when username or password is null in `passbolt.php`